### PR TITLE
workflow and volume structs given default values

### DIFF
--- a/api/v1alpha1/recipe_types.go
+++ b/api/v1alpha1/recipe_types.go
@@ -73,6 +73,12 @@ type Group struct {
 	Essential *bool `json:"essential,omitempty"`
 }
 
+const (
+	CaptureWorkflowNameDefault = "capture"
+	RecoverWorkflowNameDefault = "recover"
+	VolumeGroupNameDefault     = "volumes"
+)
+
 // Workflow is the sequence of actions to take
 type Workflow struct {
 	// Name of recipe. Names "backup" and "restore" are reserved and implicitly used by default for


### PR DESCRIPTION
- from ramendr/ramen issue #768
- define defaults for Capture and Recover Workflows and Volume Groups that can be directly referenced by scripts
- requires updates from ramen code for use (to be added on separate commit)