### PR TITLE
Define volumes group and protect and recover workflows

### DIFF
--- a/api/v1alpha1/recipe_types.go
+++ b/api/v1alpha1/recipe_types.go
@@ -22,14 +22,19 @@ type RecipeSpec struct {
 	//+listType=map
 	//+listMapKey=name
 	Groups []*Group `json:"groups"`
+	// Volumes to protect from disaster
+	//+optional
+	Volumes *Group `json:"volumes"`
 	// List of one or multiple hooks
 	//+listType=map
 	//+listMapKey=name
 	Hooks []*Hook `json:"hooks,omitempty"`
-	// Workflow is the sequence of actions to take
-	//+listType=map
-	//+listMapKey=name
-	Workflows []*Workflow `json:"workflows"`
+	// The sequence of actions to capture data to protect from disaster
+	//+optional
+	CaptureWorkflow *Workflow `json:"captureWorkflow"`
+	// The sequence of actions to recover data protected from disaster
+	//+optional
+	RecoverWorkflow *Workflow `json:"recoverWorkflow"`
 }
 
 // Groups defined in the recipe refine / narrow-down the scope of its parent groups defined in the
@@ -69,9 +74,6 @@ type Group struct {
 
 // Workflow is the sequence of actions to take
 type Workflow struct {
-	// Name of recipe. Names "backup" and "restore" are reserved and implicitly used by default for
-	// backup or restore respectively
-	Name string `json:"name"`
 	// List of the names of groups or hooks, in the order in which they should be executed
 	// Format: <group|hook>: <group or hook name>[/<hook op>]
 	Sequence []map[string]string `json:"sequence"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -228,6 +228,11 @@ func (in *RecipeSpec) DeepCopyInto(out *RecipeSpec) {
 			}
 		}
 	}
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = new(Group)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Hooks != nil {
 		in, out := &in.Hooks, &out.Hooks
 		*out = make([]*Hook, len(*in))
@@ -239,16 +244,15 @@ func (in *RecipeSpec) DeepCopyInto(out *RecipeSpec) {
 			}
 		}
 	}
-	if in.Workflows != nil {
-		in, out := &in.Workflows, &out.Workflows
-		*out = make([]*Workflow, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Workflow)
-				(*in).DeepCopyInto(*out)
-			}
-		}
+	if in.CaptureWorkflow != nil {
+		in, out := &in.CaptureWorkflow, &out.CaptureWorkflow
+		*out = new(Workflow)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.RecoverWorkflow != nil {
+		in, out := &in.RecoverWorkflow, &out.RecoverWorkflow
+		*out = new(Workflow)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/ramendr.openshift.io_recipes.yaml
+++ b/config/crd/bases/ramendr.openshift.io_recipes.yaml
@@ -39,6 +39,31 @@ spec:
                 description: Type of application the recipe is designed for. (AppType
                   is not used yet. For now, we will match the name of the app CR)
                 type: string
+              captureWorkflow:
+                description: The sequence of actions to capture data to protect from
+                  disaster
+                properties:
+                  failOn:
+                    default: any-error
+                    description: 'Implies behaviour in case of failure: any-error
+                      (default), essential-error, full-error'
+                    enum:
+                    - any-error
+                    - essential-error
+                    - full-error
+                    type: string
+                  sequence:
+                    description: 'List of the names of groups or hooks, in the order
+                      in which they should be executed Format: <group|hook>: <group
+                      or hook name>[/<hook op>]'
+                    items:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    type: array
+                required:
+                - sequence
+                type: object
               groups:
                 description: List of one or multiple groups
                 items:
@@ -323,46 +348,140 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-              workflows:
-                description: Workflow is the sequence of actions to take
-                items:
-                  description: Workflow is the sequence of actions to take
-                  properties:
-                    failOn:
-                      default: any-error
-                      description: 'Implies behaviour in case of failure: any-error
-                        (default), essential-error, full-error'
-                      enum:
-                      - any-error
-                      - essential-error
-                      - full-error
+              recoverWorkflow:
+                description: The sequence of actions to recover data protected from
+                  disaster
+                properties:
+                  failOn:
+                    default: any-error
+                    description: 'Implies behaviour in case of failure: any-error
+                      (default), essential-error, full-error'
+                    enum:
+                    - any-error
+                    - essential-error
+                    - full-error
+                    type: string
+                  sequence:
+                    description: 'List of the names of groups or hooks, in the order
+                      in which they should be executed Format: <group|hook>: <group
+                      or hook name>[/<hook op>]'
+                    items:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    type: array
+                required:
+                - sequence
+                type: object
+              volumes:
+                description: Volumes to protect from disaster
+                properties:
+                  backupRef:
+                    description: Used for groups solely used in restore workflows
+                      to refer to another group that is used in backup workflows.
+                    type: string
+                  essential:
+                    description: Defaults to true, if set to false, a failure is not
+                      necessarily handled as fatal
+                    type: boolean
+                  excludedResourceTypes:
+                    description: List of resource types to exclude
+                    items:
                       type: string
-                    name:
-                      description: Name of recipe. Names "backup" and "restore" are
-                        reserved and implicitly used by default for backup or restore
-                        respectively
+                    type: array
+                  includeClusterResources:
+                    description: Whether to include any cluster-scoped resources.
+                      If nil or true, cluster-scoped resources are included if they
+                      are associated with the included namespace-scoped resources
+                    type: boolean
+                  includedResourceTypes:
+                    description: List of resource types to include. If unspecified,
+                      all resource types are included.
+                    items:
                       type: string
-                    sequence:
-                      description: 'List of the names of groups or hooks, in the order
-                        in which they should be executed Format: <group|hook>: <group
-                        or hook name>[/<hook op>]'
-                      items:
+                    type: array
+                  labelSelector:
+                    description: Select items based on label
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
                         type: object
-                      type: array
-                  required:
-                  - name
-                  - sequence
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: Name of the group
+                    type: string
+                  nameSelector:
+                    description: If specified, resource's object name needs to match
+                      this expression. Valid for volume groups only.
+                    type: string
+                  parent:
+                    description: Name of the parent group defined in the associated
+                      Application CR. Optional - If unspecified, parent group is represented
+                      by the implicit default group of Application CR (implies the
+                      Application CR does not specify groups explicitly).
+                    type: string
+                  selectResource:
+                    description: Determines the resource type which the fields labelSelector
+                      and nameSelector apply to for selecting PVCs. Default selection
+                      is pvc. Valid for volume groups only.
+                    enum:
+                    - pvc
+                    - pod
+                    - deployment
+                    - statefulset
+                    type: string
+                  type:
+                    description: Determines the type of group - volume data only,
+                      resources only
+                    enum:
+                    - volume
+                    - resource
+                    type: string
+                required:
                 - name
-                x-kubernetes-list-type: map
+                - type
+                type: object
             required:
             - appType
             - groups
-            - workflows
             type: object
           status:
             description: RecipeStatus defines the observed state of Recipe

--- a/controllers/recipe_controller_test.go
+++ b/controllers/recipe_controller_test.go
@@ -53,8 +53,7 @@ var _ = Describe("RecipeController", func() {
 							Type: "resource",
 						},
 					},
-					Hooks:     []*Recipe.Hook{},
-					Workflows: []*Recipe.Workflow{},
+					Hooks: []*Recipe.Hook{},
 				},
 			}
 
@@ -77,8 +76,7 @@ var _ = Describe("RecipeController", func() {
 							Type: "resource",
 						},
 					},
-					Hooks:     []*Recipe.Hook{},
-					Workflows: []*Recipe.Workflow{},
+					Hooks: []*Recipe.Hook{},
 				},
 			}
 
@@ -105,7 +103,6 @@ var _ = Describe("RecipeController", func() {
 							Type: "exec",
 						},
 					},
-					Workflows: []*Recipe.Workflow{},
 				},
 			}
 
@@ -129,7 +126,6 @@ var _ = Describe("RecipeController", func() {
 							Type: "exec",
 						},
 					},
-					Workflows: []*Recipe.Workflow{},
 				},
 			}
 
@@ -164,7 +160,6 @@ var _ = Describe("RecipeController", func() {
 							Ops:  ops,
 						},
 					},
-					Workflows: []*Recipe.Workflow{},
 				},
 			}
 		}
@@ -220,7 +215,6 @@ var _ = Describe("RecipeController", func() {
 							},
 						},
 					},
-					Workflows: []*Recipe.Workflow{},
 				},
 			}
 
@@ -248,64 +242,12 @@ var _ = Describe("RecipeController", func() {
 							},
 						},
 					},
-					Workflows: []*Recipe.Workflow{},
 				},
 			}
 
 			err := k8sClient.Create(context.TODO(), recipe)
 
 			Expect(err).ToNot(BeNil())
-		})
-	})
-
-	Context("Workflows", func() {
-		It("allow unique names", func() {
-			recipe := &Recipe.Recipe{
-				TypeMeta:   metav1.TypeMeta{Kind: "Recipe", APIVersion: "ramendr.openshift.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "test-recipe", Namespace: testNamespace.Name},
-				Spec: Recipe.RecipeSpec{
-					Groups: []*Recipe.Group{},
-					Hooks:  []*Recipe.Hook{},
-					Workflows: []*Recipe.Workflow{
-						{
-							Name:     "workflow-1",
-							Sequence: []map[string]string{},
-						},
-						{
-							Name:     "workflow-2",
-							Sequence: []map[string]string{},
-						},
-					},
-				},
-			}
-
-			err := k8sClient.Create(context.TODO(), recipe)
-
-			Expect(err).To(BeNil())
-		})
-		It("error on duplicate names", func() {
-			recipe := &Recipe.Recipe{
-				TypeMeta:   metav1.TypeMeta{Kind: "Recipe", APIVersion: "ramendr.openshift.io/v1alpha1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "test-recipe", Namespace: testNamespace.Name},
-				Spec: Recipe.RecipeSpec{
-					Groups: []*Recipe.Group{},
-					Hooks:  []*Recipe.Hook{},
-					Workflows: []*Recipe.Workflow{
-						{
-							Name:     "workflow-1",
-							Sequence: []map[string]string{},
-						},
-						{
-							Name:     "workflow-2",
-							Sequence: []map[string]string{},
-						},
-					},
-				},
-			}
-
-			err := k8sClient.Create(context.TODO(), recipe)
-
-			Expect(err).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
# Proposed changes
Only two workflows are needed.  Name them so the user doesn't have to name them nor reference them.
Only one volume selector is needed.  Name it so the user doesn't have to name it nor reference it.

- Define `spec` fields
   - `volumes`
   - `protectWorkflow`
   - `recoverWorkflow`
- Remove fields
   - `spec.workflows`
   - `workflow.name`