### PR TITLE
Dockerfile: change base image to ubi and add license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,14 @@ COPY controllers/ controllers/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi
 WORKDIR /
 COPY --from=builder /workspace/manager .
+
+
+RUN mkdir -p licenses
+COPY LICENSE licenses/LICENSE
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
This PR changes the base image for the operator to Red Hat UBI image and also adds the license file.