### PR TITLE
Restore Group.includedNamespaces, Hook.namespace

### DIFF
--- a/api/v1alpha1/recipe_types.go
+++ b/api/v1alpha1/recipe_types.go
@@ -69,6 +69,9 @@ type Group struct {
 	// Whether to include any cluster-scoped resources. If nil or true, cluster-scoped resources are
 	// included if they are associated with the included namespace-scoped resources
 	IncludeClusterResources *bool `json:"includeClusterResources,omitempty"`
+	// List of namespaces to include.
+	//+optional
+	IncludedNamespaces []string `json:"includedNamespaces,omitempty"`
 	// Defaults to true, if set to false, a failure is not necessarily handled as fatal
 	Essential *bool `json:"essential,omitempty"`
 }
@@ -88,6 +91,9 @@ type Workflow struct {
 type Hook struct {
 	// Hook name, unique within the Recipe CR
 	Name string `json:"name"`
+	// Namespace
+	//+optional
+	Namespace string `json:"namespace,omitempty"`
 	// Hook type
 	// +kubebuilder:validation:Enum=exec;scale;check
 	Type string `json:"type"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -69,6 +69,11 @@ func (in *Group) DeepCopyInto(out *Group) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IncludedNamespaces != nil {
+		in, out := &in.IncludedNamespaces, &out.IncludedNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Essential != nil {
 		in, out := &in.Essential, &out.Essential
 		*out = new(bool)

--- a/config/crd/bases/ramendr.openshift.io_recipes.yaml
+++ b/config/crd/bases/ramendr.openshift.io_recipes.yaml
@@ -91,6 +91,11 @@ spec:
                         If nil or true, cluster-scoped resources are included if they
                         are associated with the included namespace-scoped resources
                       type: boolean
+                    includedNamespaces:
+                      description: List of namespaces to include.
+                      items:
+                        type: string
+                      type: array
                     includedResourceTypes:
                       description: List of resource types to include. If unspecified,
                         all resource types are included.
@@ -269,6 +274,9 @@ spec:
                       description: If specified, resource's object name needs to match
                         this expression
                       type: string
+                    namespace:
+                      description: Namespace
+                      type: string
                     onError:
                       default: fail
                       description: Default behavior in case of failing operations
@@ -394,6 +402,11 @@ spec:
                       If nil or true, cluster-scoped resources are included if they
                       are associated with the included namespace-scoped resources
                     type: boolean
+                  includedNamespaces:
+                    description: List of namespaces to include.
+                    items:
+                      type: string
+                    type: array
                   includedResourceTypes:
                     description: List of resource types to include. If unspecified,
                       all resource types are included.


### PR DESCRIPTION
Add support for multiple namespaces by restoring two namespace name inputs from the Backup/Restore recipe:
- Group `includedNamespaces` - a list of namespace names to capture resources from
- Hook `namespace` - name of namespace to containing pod to execute hook in