### PR TITLE
Make groups field optional

### DIFF
--- a/api/v1alpha1/recipe_types.go
+++ b/api/v1alpha1/recipe_types.go
@@ -21,6 +21,7 @@ type RecipeSpec struct {
 	// List of one or multiple groups
 	//+listType=map
 	//+listMapKey=name
+	//+optional
 	Groups []*Group `json:"groups"`
 	// Volumes to protect from disaster
 	//+optional

--- a/config/crd/bases/ramendr.openshift.io_recipes.yaml
+++ b/config/crd/bases/ramendr.openshift.io_recipes.yaml
@@ -494,7 +494,6 @@ spec:
                 type: object
             required:
             - appType
-            - groups
             type: object
           status:
             description: RecipeStatus defines the observed state of Recipe


### PR DESCRIPTION
# Problem
The groups field is required though it should not be.

# Solution
Mark groups field optional and regenerate CRD.