### PR TITLE
bundle: add non-standalone annotation to the csv

### DIFF
--- a/config/manifests-crd/bases/recipe.clusterserviceversion.yaml
+++ b/config/manifests-crd/bases/recipe.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.operatorframework.io/operator-type: non-standalone
   name: recipe.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
non-standalone annotation will hide the operator from the operator hub page in the openshift console.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2283024