### PR TITLE
api: add an option to skip hook if no resource is found

### DIFF
--- a/api/v1alpha1/recipe_types.go
+++ b/api/v1alpha1/recipe_types.go
@@ -149,6 +149,9 @@ type Hook struct {
 	Chks []*Check `json:"chks,omitempty"`
 	// Defaults to true, if set to false, a failure is not necessarily handled as fatal
 	Essential *bool `json:"essential,omitempty"`
+	// Flag to skip a Hook.
+	// +kubebuilder:default=false
+	SkipHookIfNotPresent bool `json:"skipHookIfNotPresent,omitempty"`
 }
 
 // Operation to be invoked by the hook

--- a/config/crd/bases/ramendr.openshift.io_recipes.yaml
+++ b/config/crd/bases/ramendr.openshift.io_recipes.yaml
@@ -385,6 +385,10 @@ spec:
                         Boolean flag that indicates whether to execute command on a single pod or on all pods that
                         match the selector
                       type: boolean
+                    skipHookIfNotPresent:
+                      default: false
+                      description: Flag to skip a Hook.
+                      type: boolean
                     timeout:
                       description: Default timeout in seconds applied to custom and
                         built-in operations. If not specified, equals to 30s.


### PR DESCRIPTION
A boolean field called SkipHookIfNotPresent is added to the Hook type. This boolean has the default value of false. 

If the field is set to true then on timeout of the hook, the hook operation is considered as a success if no resources were found matching the selectors provided. 

If one or more resources are found but the condition cannot be satisfied or the operation cannot be completed then the hook operation is considered as a failure.